### PR TITLE
ghidra 11.0.3,20240410

### DIFF
--- a/Casks/ghidra.rb
+++ b/Casks/ghidra.rb
@@ -1,6 +1,6 @@
 cask "ghidra" do
-  version "11.0.2,20240326"
-  sha256 "4f16ae3f288f8c01fd1872e8e55b25c79744e7b1e8a9383c5e576668ca7d1906"
+  version "11.0.3,20240410"
+  sha256 "2462a2d0ab11e30f9e907cd3b4aa6b48dd2642f325617e3d922c28e752be6761"
 
   url "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_#{version.csv.first}_build/ghidra_#{version.csv.first}_PUBLIC_#{version.csv.second}.zip",
       verified: "github.com/NationalSecurityAgency/ghidra/"


### PR DESCRIPTION
Had to open this manually since autobump is having issues with this cask being in both this tap and the main cask repo.