### PR TITLE
ryujinx: deprecate

### DIFF
--- a/Casks/ryujinx.rb
+++ b/Casks/ryujinx.rb
@@ -8,6 +8,8 @@ cask "ryujinx" do
   desc "Nintendo Switch emulator"
   homepage "https://ryujinx.org/"
 
+  deprecate! date: "2024-10-01", because: :no_longer_available
+
   depends_on macos: ">= :monterey"
 
   app "Ryujinx.app"


### PR DESCRIPTION
Upstream shutdown after being contacted by Nintendo.