### PR TITLE
README: list ryujinx as no longer available

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ Since I prefer to install everything using `brew`, I've created this tap to host
 
 [`greenlight`](https://github.com/unknownskl/greenlight) (Client for xCloud and Xbox home streaming)
 
-[`ryujinx`](https://ryujinx.org) (Nintendo Switch emulator)
+~~[`ryujinx`](https://ryujinx.org) (Nintendo Switch emulator)~~ [No longer available]
 
 [`wizcli`](https://www.wiz.io) (CLI for the Wiz platform)


### PR DESCRIPTION
This can no longer be downloaded, but I'm leaving it in the tap as disabled for anyone that has it installed currently.