### PR TITLE
autobump: add SSH commit signing and disable deployments

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -20,7 +20,9 @@ permissions:
 jobs:
   autobump:
     name: Autobump casks
-    environment: autobump
+    environment:
+      name: autobump
+      deployment: false
     env:
       HOMEBREW_DEVELOPER: 1
     runs-on: macos-26
@@ -32,10 +34,24 @@ jobs:
           core: true
           cask: true
 
-      - name: Configure Git user
-        uses: Homebrew/actions/git-user-config@main
-        with:
-          username: fuyunohoshi
+      - name: Set up commit signing
+        env:
+          SSH_SIGNING_KEY: ${{ secrets.SSH_SIGNING_KEY }}
+        run: |
+          git config user.name "fuyunohoshi"
+          git config user.email "165941061+fuyunohoshi@users.noreply.github.com"
+          eval $(ssh-agent)
+          echo "SSH_AUTH_SOCK=${SSH_AUTH_SOCK}" >> "${GITHUB_ENV}"
+          echo "SSH_AGENT_PID=${SSH_AGENT_PID}" >> "${GITHUB_ENV}"
+          pubkey=$(ssh-keygen -y -f /dev/stdin <<< "${SSH_SIGNING_KEY}")
+          ssh-add -q - <<< "${SSH_SIGNING_KEY}"
+          allowed_signer="$(git config get user.email) ${pubkey}"
+          mkdir -p ~/.ssh
+          echo "${allowed_signer}" >> ~/.ssh/allowed_signers
+          git config --global gpg.format ssh
+          git config --global commit.gpgsign true
+          git config --global user.signingkey "${pubkey}"
+          git config --global gpg.ssh.allowedSignersFile ~/.ssh/allowed_signers
 
       - name: Bump casks
         id: autobump


### PR DESCRIPTION
## Summary
- Replace `Homebrew/actions/git-user-config` with SSH commit signing setup, matching macOSdb and Brewy workflows
- Disable deployments for the `autobump` environment (`deployment: false`)