### PR TITLE
ci: replace actionlint with zizmor, add per-tap actionlint config

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+self-hosted-runner:
+  labels: []
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      - 'unexpected key "deployment"'

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           git config user.name "fuyunohoshi"
           git config user.email "165941061+fuyunohoshi@users.noreply.github.com"
-          eval $(ssh-agent)
+          eval "$(ssh-agent)"
           echo "SSH_AUTH_SOCK=${SSH_AUTH_SOCK}" >> "${GITHUB_ENV}"
           echo "SSH_AGENT_PID=${SSH_AGENT_PID}" >> "${GITHUB_ENV}"
           pubkey=$(ssh-keygen -y -f /dev/stdin <<< "${SSH_SIGNING_KEY}")

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,17 +1,21 @@
-name: Actionlint
+name: zizmor
 
 on:
   push:
     branches:
       - main
+    paths:
+      - ".github/workflows/**"
   pull_request:
+    paths:
+      - ".github/workflows/**"
 
 defaults:
   run:
     shell: bash -xeuo pipefail {0}
 
 concurrency:
-  group: "actionlint-${{ github.ref }}"
+  group: "zizmor-${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
@@ -22,8 +26,8 @@ env:
 permissions: {}
 
 jobs:
-  workflow_syntax:
-    name: Workflow syntax
+  zizmor:
+    name: Analyze
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,8 +41,8 @@ jobs:
           core: false
           cask: false
 
-      - name: Install tools
-        run: brew install actionlint shellcheck zizmor
+      - name: Install zizmor
+        run: brew install zizmor
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -55,24 +59,20 @@ jobs:
           name: results.sarif
           path: results.sarif
 
-      - run: actionlint
-
   upload_sarif:
     name: Upload SARIF
-    needs: workflow_syntax
-    # We want to always upload this even if `actionlint` failed.
-    if: always() && !contains(fromJSON('["cancelled", "skipped"]'), needs.workflow_syntax.result)
+    needs: zizmor
+    if: always() && !contains(fromJSON('["cancelled", "skipped"]'), needs.zizmor.result)
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      security-events: write # Upload SARIF results to GitHub Code Scanning
+      security-events: write # required to upload SARIF results
     steps:
       - name: Download SARIF file
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: results.sarif
           path: results.sarif
-
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
         with:


### PR DESCRIPTION
## Summary

- Replace standalone `actionlint.yml` workflow with `zizmor.yml` (zizmor-only, matching Brewy/macOSdb pattern)
- Add `.github/actionlint.yaml` config to ignore `deployment` key error (requires Homebrew/brew#21878)
- Fix SC2046 shellcheck warning in `autobump.yml` (unquoted `$(ssh-agent)`)