### PR TITLE
fix(ci): widen actionlint paths glob to match absolute paths

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,6 @@
 self-hosted-runner:
   labels: []
 paths:
-  .github/workflows/**/*.{yml,yaml}:
+  '**/*.{yml,yaml}':
     ignore:
       - 'unexpected key "deployment"'


### PR DESCRIPTION
`brew style` passes absolute file paths to actionlint, but the `.github/workflows/**/*.{yml,yaml}` glob in the per-tap config only matches relative paths. This caused the `deployment` key ignore pattern to not apply in CI, even after Homebrew/brew#21843 landed.

Widening the glob to `**/*.{yml,yaml}` matches regardless of path prefix.