### PR TITLE
feat: add pinprick cask

### DIFF
--- a/Casks/pinprick.rb
+++ b/Casks/pinprick.rb
@@ -1,0 +1,15 @@
+cask "pinprick" do
+  version "0.1.1"
+  sha256 "b3cbcc941d0fa65756698ee59b75222265e45fca5d4bcb3ca4413cf22a925662"
+
+  url "https://github.com/p-linnane/pinprick/releases/download/v#{version}/pinprick-#{version}-aarch64-apple-darwin.tar.gz"
+  name "pinprick"
+  desc "Pin your GitHub Actions. Prick holes in their supply chain security"
+  homepage "https://github.com/p-linnane/pinprick"
+
+  depends_on arch: :arm64
+
+  binary "pinprick"
+
+  zap trash: "~/.config/pinprick"
+end

--- a/README.md
+++ b/README.md
@@ -18,4 +18,5 @@ brew install --cask <cask-name>
 | [`apple-container`](https://github.com/apple/container) | Create and run Linux containers using lightweight virtual machines |
 | [`lumafly`](https://themulhima.github.io/Lumafly/) | Mod manager for Hollow Knight |
 | [`macosdb`](https://github.com/p-linnane/macOSdb) | Browse and compare open-source components shipped in IPSW files |
+| [`pinprick`](https://github.com/p-linnane/pinprick) | Pin your GitHub Actions and prick holes in their supply chain security |
 | [`scarab`](https://github.com/fifty-six/Scarab) | Mod manager for Hollow Knight |


### PR DESCRIPTION
Add pinprick cask for GitHub Actions supply chain security CLI.