### PR TITLE
feat(pinprick): add linux support

### DIFF
--- a/Casks/pinprick.rb
+++ b/Casks/pinprick.rb
@@ -1,13 +1,24 @@
 cask "pinprick" do
-  version "0.1.1"
-  sha256 "b3cbcc941d0fa65756698ee59b75222265e45fca5d4bcb3ca4413cf22a925662"
+  arch arm: "aarch64", intel: "x86_64"
+  os macos: "apple-darwin", linux: "unknown-linux-gnu"
 
-  url "https://github.com/p-linnane/pinprick/releases/download/v#{version}/pinprick-#{version}-aarch64-apple-darwin.tar.gz"
+  version "0.1.1"
+
+  url "https://github.com/p-linnane/pinprick/releases/download/v#{version}/pinprick-#{version}-#{arch}-#{os}.tar.gz"
   name "pinprick"
   desc "Pin your GitHub Actions. Prick holes in their supply chain security"
   homepage "https://github.com/p-linnane/pinprick"
 
-  depends_on arch: :arm64
+  on_macos do
+    sha256 "b3cbcc941d0fa65756698ee59b75222265e45fca5d4bcb3ca4413cf22a925662"
+
+    depends_on arch: :arm64
+  end
+
+  on_linux do
+    sha256 arm64_linux:  "1b36066b1511d72e4f57d0e0a01cafe511f7ca4353a996e02e671c0ddd3b20be",
+           x86_64_linux: "008ea8843d660754223672c4d9daac4a239f7db72d0a18f8109a7fdd2a40f3b2"
+  end
 
   binary "pinprick"
 


### PR DESCRIPTION
Add Linux support for the pinprick cask with platform-specific sha256 checksums and architecture handling.