### PR TITLE
ci(autobump): migrate from fuyunohoshi to starhaven-bot

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -20,13 +20,20 @@ permissions:
 jobs:
   autobump:
     name: Autobump casks
-    environment:
-      name: autobump
-      deployment: false
+    environment: starhaven
     env:
       HOMEBREW_DEVELOPER: 1
     runs-on: macos-26
+    permissions:
+      contents: read
     steps:
+      - name: Mint bot token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@main
@@ -34,32 +41,35 @@ jobs:
           core: true
           cask: true
 
-      - name: Set up commit signing
+      - name: Configure bot identity and tap remote
         env:
-          SSH_SIGNING_KEY: ${{ secrets.SSH_SIGNING_KEY }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          git config user.name "fuyunohoshi"
-          git config user.email "165941061+fuyunohoshi@users.noreply.github.com"
-          eval "$(ssh-agent)"
-          echo "SSH_AUTH_SOCK=${SSH_AUTH_SOCK}" >> "${GITHUB_ENV}"
-          echo "SSH_AGENT_PID=${SSH_AGENT_PID}" >> "${GITHUB_ENV}"
-          pubkey=$(ssh-keygen -y -f /dev/stdin <<< "${SSH_SIGNING_KEY}")
-          ssh-add -q - <<< "${SSH_SIGNING_KEY}"
-          allowed_signer="$(git config get user.email) ${pubkey}"
-          mkdir -p ~/.ssh
-          echo "${allowed_signer}" >> ~/.ssh/allowed_signers
-          git config --global gpg.format ssh
-          git config --global commit.gpgsign true
-          git config --global user.signingkey "${pubkey}"
-          git config --global gpg.ssh.allowedSignersFile ~/.ssh/allowed_signers
+          BOT_USER="${APP_SLUG}[bot]"
+          BOT_ID=$(gh api "/users/${BOT_USER}" --jq .id)
+          BOT_EMAIL="${BOT_ID}+${BOT_USER}@users.noreply.github.com"
+
+          git config --global user.name "${BOT_USER}"
+          git config --global user.email "${BOT_EMAIL}"
+
+          TAP_DIR=$(brew --repo p-linnane/homebrew-tap)
+          git -C "${TAP_DIR}" remote set-url origin \
+            "https://x-access-token:${APP_TOKEN}@github.com/p-linnane/homebrew-tap.git"
+
+          {
+            echo "BOT_USER=${BOT_USER}"
+            echo "BOT_EMAIL=${BOT_EMAIL}"
+          } >> "${GITHUB_ENV}"
 
       - name: Bump casks
         id: autobump
         env:
           HOMEBREW_TEST_BOT_AUTOBUMP: 1
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.BOT_TOKEN }}
-          HOMEBREW_GIT_COMMITTER_NAME: fuyunohoshi
-          HOMEBREW_GIT_COMMITTER_EMAIL: 165941061+fuyunohoshi@users.noreply.github.com
+          HOMEBREW_GITHUB_API_TOKEN: ${{ steps.app-token.outputs.token }}
+          HOMEBREW_GIT_COMMITTER_NAME: ${{ env.BOT_USER }}
+          HOMEBREW_GIT_COMMITTER_EMAIL: ${{ env.BOT_EMAIL }}
           CASKS: ${{ inputs.casks }}
         continue-on-error: true
         run: |


### PR DESCRIPTION
Drops SSH signing key and PAT in favor of a short-lived token from the starhaven-bot App scoped to a new `starhaven` environment. Commits remain Unverified since `brew bump` uses local git rather than the API.