### PR TITLE
ci(autobump): disable deployment entries

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -20,7 +20,9 @@ permissions:
 jobs:
   autobump:
     name: Autobump casks
-    environment: starhaven
+    environment:
+      name: starhaven
+      deployment: false
     env:
       HOMEBREW_DEVELOPER: 1
     runs-on: macos-26


### PR DESCRIPTION
## Summary
- Set `deployment: false` on the autobump `starhaven` environment