### PR TITLE
ci: migrate bot token minting to client-id

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -33,7 +33,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Set up Homebrew


### PR DESCRIPTION
Migrate `actions/create-github-app-token` from the deprecated `app-id` input to `client-id`, referencing the client ID via the `APP_CLIENT_ID` repo variable (set per GitHub's recommendation for non-sensitive values). `APP_PRIVATE_KEY` secret is unchanged.