### PR TITLE
ci: rename bot environment to fuyunohoshi

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -21,7 +21,7 @@ jobs:
   autobump:
     name: Autobump casks
     environment:
-      name: starhaven
+      name: fuyunohoshi
       deployment: false
     env:
       HOMEBREW_DEVELOPER: 1


### PR DESCRIPTION
Renames the autobump environment from `starhaven` to `fuyunohoshi` to match the new personal-account GitHub App that mints bot tokens for this tap.