### PR TITLE
ci: silence zizmor unpinned-images on the matrix container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     name: ${{ matrix.name }}
     needs: generate-matrix
     runs-on: ${{ matrix.runner }}
-    container: ${{ matrix.container || null }}
+    container: ${{ matrix.container || null }} # zizmor: ignore[unpinned-images]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Zizmor's `unpinned-images` audit was raising two code-scanning alerts on the CI matrix's `container: ${{ matrix.container || null }}` — the stock Homebrew tap-CI template line. Both are false positives: `matrix.container` is generated at runtime by `brew generate-cask-ci-matrix` so it can't be digest-pinned at lint time, and the `null` fallback isn't an image at all. This adds an inline `# zizmor: ignore[unpinned-images]` to that line, which clears both findings while leaving the rest of the workflow audited for the rule.