### PR TITLE
ci: pin Homebrew/actions/setup-homebrew to a SHA

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@main
+        uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
         with:
           core: true
           cask: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Set up Homebrew
         id: setup-homebrew
-        uses: Homebrew/actions/setup-homebrew@main
+        uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
         with:
           core: true
           cask: true
@@ -136,7 +136,7 @@ jobs:
     steps:
       - name: Set up Homebrew
         id: setup-homebrew
-        uses: Homebrew/actions/setup-homebrew@main
+        uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
         with:
           core: true
           cask: true

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,7 +1,0 @@
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        # Homebrew/actions does not publish versioned refs; keep this exception
-        # scoped to upstream Homebrew actions.
-        Homebrew/actions/*: ref-pin

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,6 @@ Before committing README link changes:
   directory in this tap.
 - `.github/workflows/`: CI, autobump automation, workflow security checks, and
   cask audit/fetch/install tests.
-- `.github/zizmor.yml`: workflow audit policy.
 - `lychee.toml`: README link-check configuration.
 - `README.md`: user-facing tap overview and cask list.
 
@@ -97,8 +96,8 @@ Before committing README link changes:
 2. Do not use mutable cask URLs, `latest` release URLs, or `sha256 :no_check`.
 3. Before trusting token-based Homebrew checks, verify that
    `brew --repo p-linnane/tap` points at the checkout you are editing.
-4. Keep the `Homebrew/actions/*` zizmor exception scoped to upstream Homebrew
-   actions; do not generalize it to other moving refs.
+4. Pin `Homebrew/actions/*` to a full commit SHA and keep the published CalVer
+   tag in the adjacent version comment.
 
 ## Commit and PR conventions
 


### PR DESCRIPTION
Homebrew/actions publishes CalVer release tags, so `setup-homebrew` in `ci.yml` and `autobump.yml` is pinned to the `2026.07.10.1` commit instead of tracking `@main`.

With a full SHA in place, the zizmor ref-pin exception is no longer needed: `.github/zizmor.yml` is removed and zizmor's default full-SHA policy applies.
