### PR TITLE
docs: drop the note about retired third-party casks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@ To install from the new tap directly:
 brew tap starhaven-io/tap
 ```
 
-The other casks once maintained here — `apple-container`, `lumafly`, and
-`scarab` — are no longer published from this repository.
-
 ## License
 
 This tap is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
Drop the closing note that named `apple-container`, `lumafly`, and `scarab`. Those were third-party tools rather than p-linnane software, so calling them out in the retirement notice added noise. The tap's migration story is only about `macosdb` and `pinprick`, which the notice already covers.
